### PR TITLE
Fix Double, Int, and Zip Code Validation

### DIFF
--- a/Dockerfile~test
+++ b/Dockerfile~test
@@ -1,11 +1,12 @@
-FROM swift:4
+FROM moonshotenergy/swift:4
+
 
 WORKDIR /code
 
-COPY Package.swift /code/.
+COPY Package.swift /code/
 
-
-RUN swift build || true
+RUN swift -version
+RUN swift package resolve
 
 COPY ./Sources /code/Sources
 COPY ./Tests /code/Tests

--- a/Sources/SwiftValidator/DoubleRule.swift
+++ b/Sources/SwiftValidator/DoubleRule.swift
@@ -30,6 +30,21 @@ public class DoubleRule: Rule {
         if let d = value as? Double {
             number = d
         } else if let s = value as? String {
+            // This part of the code makes sure that if we've got a string here
+            // that there are no pieces outside what a double might contain.
+            // This is so we will not get false validations on strings that contain digits
+            // and needs to be here because casting as? Int and as? Dobule
+            // are fundamentally flawed in Swift and do not work quite right.
+            // So... don't get rid of this without lots of testing
+
+            // Make a character set of digits, commas, and decimal points
+            // (Things we could have in a double)
+            let doubleCharacters = CharacterSet.decimalDigits.union(CharacterSet(charactersIn: ".,"))
+            // If trimming characters returns anything, we have characters outside of what
+            // might be a double, so don't validate it (false)
+            guard s.trimmingCharacters(in: doubleCharacters).isEmpty else {
+                return false
+            }
 
             let formatter = NumberFormatter()
             formatter.locale = self.locale

--- a/Sources/SwiftValidator/IntegerRule.swift
+++ b/Sources/SwiftValidator/IntegerRule.swift
@@ -26,6 +26,22 @@ public class IntegerRule: Rule {
             number = i
         } else if let s = value as? String,
             let d = parseNumber(s) {
+
+            // This part of the code makes sure that if we've got a string here
+            // that there are no pieces outside what a double might contain.
+            // This is so we will not get false validations on strings that contain digits
+            // and needs to be here because casting as? Int and as? Dobule
+            // are fundamentally flawed in Swift and do not work quite right.
+            // So... don't get rid of this without lots of testing
+
+            // (Things we could have in int)
+            let intChars = CharacterSet.decimalDigits
+            // If trimming characters returns anything, we have characters outside of what
+            // might be an Int, so don't validate it (false)
+            guard s.trimmingCharacters(in: intChars).isEmpty else {
+                return false
+            }
+
             number = Int(d)
         }
         guard let n = number, n >= min, n <= max  else { return false }

--- a/Sources/SwiftValidator/ZipCodeRule.swift
+++ b/Sources/SwiftValidator/ZipCodeRule.swift
@@ -15,6 +15,12 @@ public class ZipCodeRule: Rule {
     public func validate(value: Any) -> Bool {
         guard let value = value as? String  else { return false }
 
+        // Make sure this is only digits
+        let digitChars = CharacterSet.decimalDigits
+        guard value.trimmingCharacters(in: digitChars).isEmpty else {
+            return false
+        }
+
         guard let regex = try? NSRegularExpression(pattern:"(\\d{5})", options: []) else { return false }
         let matches = regex.matches(in: value, options: .reportCompletion, range:  NSRange(location: 0, length: value.utf8.count))
         var valid: String?

--- a/Tests/SwiftValidatorTests/ValidatorTests.swift
+++ b/Tests/SwiftValidatorTests/ValidatorTests.swift
@@ -6,8 +6,7 @@ class ValidatorTests: XCTestCase {
     func testZipRule() {
         let zipCodeRule = ZipCodeRule()
 
-        XCTAssertTrue(zipCodeRule.validate(value: "meine plz ist 14109 okay"), "PASS")
-        XCTAssertEqual(zipCodeRule.validatedValue as? String, "14109")
+        XCTAssertFalse(zipCodeRule.validate(value: "meine plz ist 14109 okay"), "PASS")
 
         XCTAssertTrue(zipCodeRule.validate(value: "31509"), "PASS")
         XCTAssertEqual(zipCodeRule.validatedValue as? String, "31509")
@@ -18,8 +17,7 @@ class ValidatorTests: XCTestCase {
         XCTAssertFalse(zipCodeRule.validate(value: "315"), "TOO SHORT")
         XCTAssertNil(zipCodeRule.validatedValue)
 
-        XCTAssertTrue(zipCodeRule.validate(value: "aR31500"))
-        XCTAssertEqual(zipCodeRule.validatedValue as? String, "31500")
+        XCTAssertFalse(zipCodeRule.validate(value: "aR31500"))
 
         XCTAssertFalse(zipCodeRule.validate(value: "qwert"), "ONLY NUMBERS")
 
@@ -63,7 +61,7 @@ class ValidatorTests: XCTestCase {
             XCTAssertFalse(intRule.validate(value: $0))
         }
 
-        ["number is 10", "250 kWh", "I think it was 100 or so"].forEach {
+        ["10", "250", "100"].forEach {
             XCTAssertTrue(intRule.validate(value: $0))
         }
 
@@ -205,7 +203,7 @@ class ValidatorTests: XCTestCase {
             "b": "DE44500105175407324931",
             "c": "250",
             "d": "john.appleseed@apple.com",
-            "e": "1024,5 kWh",
+            "e": "1024,5",
             "e1": 200,
             "f": "kWh",
             "i": "12.10.1980",


### PR DESCRIPTION
So as it turns out, casting `as? Int` or `as? Double` are still fundamentally flawed in Swift and do not quite work perfectly. So, to solve this, the original developer added a part to the code where it would first be converted to a string, then the number would be parsed out of that. Aside from the fact that we should not have to do this (and we unfortuanately need to)...

This mehtod of validation was likely originally intentional, though no longer needed for the purpose of this validator. (i.e. Strings like "2500 kWh und 14109 Berlin" should not validate to a double, because NLG Entity Extraction should be used to solve this instead). If we are trying to use this data, this should not validate, because we should also be trying just "2500" as an by itself thanks to NLG.

This commit resolves these issues by checking the converted strings for Int and Double conditions before validating from a String for Int, Double, and Zip Codes. It also updates the related unit tests.